### PR TITLE
Mandatory title and design_description in experiment block

### DIFF
--- a/scripts/controlled_vocabulary/fixed_fields.yml
+++ b/scripts/controlled_vocabulary/fixed_fields.yml
@@ -48,7 +48,7 @@ experiment:
       cv: []
       field_type: TEXT_FIELD
     - name: title
-      cardinality: optional
+      cardinality: mandatory
       description: Short text that can be used to call out experiment records in searches or in displays. This element is technically optional but should be used for all new records.
       units: ""
       regex: ""
@@ -69,7 +69,7 @@ experiment:
       cv: []
       field_type: TEXT_FIELD
     - name: design_description
-      cardinality: optional
+      cardinality: mandatory
       description: Goal and setup of the individual library including library was constructed.
       units: ""
       regex: ""


### PR DESCRIPTION
Experiment `title` and `design_description` are actually mandatory. This will close #57.